### PR TITLE
Use MISE_CONFIG_ROOT and add --catalog flag to apply

### DIFF
--- a/.mise/tasks/apply
+++ b/.mise/tasks/apply
@@ -3,15 +3,24 @@
 #USAGE arg "[hooks...]" help="Hook names to apply (e.g., session-id anti-compact). If none specified, applies all."
 #USAGE flag "--dry-run" help="Show what would change without applying"
 #USAGE flag "--scope <scope>" default="user" help="Settings scope: user, project, or local"
+#USAGE flag "--catalog <path>" var=#true help="Additional catalog directories to search"
 
 set -eu
 
 DRY_RUN="${usage_dry_run:-false}"
 SCOPE="${usage_scope:-user}"
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
-CATALOG_DIR="$REPO_DIR/catalog"
+# Build list of catalog directories: built-in first, then any --catalog additions
+CATALOG_DIRS=("${MISE_CONFIG_ROOT:?MISE_CONFIG_ROOT not set}/catalog")
+if [ -n "${usage_catalog:-}" ]; then
+  for dir in $usage_catalog; do
+    if [ ! -d "$dir" ]; then
+      echo "Error: Catalog directory '$dir' does not exist" >&2
+      exit 1
+    fi
+    CATALOG_DIRS+=("$dir")
+  done
+fi
 
 case "$SCOPE" in
   user)    SETTINGS_FILE="$HOME/.claude/settings.json" ;;
@@ -25,16 +34,26 @@ CATALOG_FILES=()
 HOOKS="${usage_hooks:-}"
 if [ -n "$HOOKS" ]; then
   for NAME in $HOOKS; do
-    FILE="$CATALOG_DIR/${NAME}.json"
-    if [ ! -f "$FILE" ]; then
-      echo "Error: No catalog entry for '$NAME' (expected $FILE)" >&2
+    FOUND=""
+    for dir in "${CATALOG_DIRS[@]}"; do
+      FILE="$dir/${NAME}.json"
+      if [ -f "$FILE" ]; then
+        FOUND="$FILE"
+        break
+      fi
+    done
+    if [ -z "$FOUND" ]; then
+      SEARCHED=$(printf ", %s" "${CATALOG_DIRS[@]}")
+      echo "Error: No catalog entry for '$NAME' (searched:${SEARCHED:1})" >&2
       exit 1
     fi
-    CATALOG_FILES+=("$FILE")
+    CATALOG_FILES+=("$FOUND")
   done
 else
-  for f in "$CATALOG_DIR"/*.json; do
-    CATALOG_FILES+=("$f")
+  for dir in "${CATALOG_DIRS[@]}"; do
+    for f in "$dir"/*.json; do
+      [ -f "$f" ] && CATALOG_FILES+=("$f")
+    done
   done
 fi
 

--- a/.mise/tasks/catalog
+++ b/.mise/tasks/catalog
@@ -4,9 +4,7 @@
 
 set -eu
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
-CATALOG_DIR="$REPO_DIR/catalog"
+CATALOG_DIR="${MISE_CONFIG_ROOT:?MISE_CONFIG_ROOT not set}/catalog"
 
 if [ ! -d "$CATALOG_DIR" ]; then
   echo "No catalog directory found" >&2

--- a/.mise/tasks/dashboard
+++ b/.mise/tasks/dashboard
@@ -4,11 +4,8 @@
 
 set -eu
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
-
 if [ -n "${usage_config:-}" ]; then
   export HOOKERS_DASHBOARD_CONFIG="$usage_config"
 fi
 
-exec bash "$REPO_DIR/scripts/dashboard.sh"
+exec bash "${MISE_CONFIG_ROOT:?MISE_CONFIG_ROOT not set}/scripts/dashboard.sh"

--- a/.mise/tasks/provider
+++ b/.mise/tasks/provider
@@ -5,9 +5,7 @@
 set -eu
 
 NAME="$usage_name"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
-PROVIDER="$REPO_DIR/scripts/providers/${NAME}.sh"
+PROVIDER="${MISE_CONFIG_ROOT:?MISE_CONFIG_ROOT not set}/scripts/providers/${NAME}.sh"
 
 if [ ! -f "$PROVIDER" ]; then
   echo "Error: No provider '$NAME' (expected $PROVIDER)" >&2

--- a/.mise/tasks/test/apply
+++ b/.mise/tasks/test/apply
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 #MISE description="Run apply/unapply tests (BATS)"
 set -e
-REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-bats "$REPO_DIR/test/apply.bats"
+bats "${MISE_CONFIG_ROOT:?MISE_CONFIG_ROOT not set}/test/apply.bats"

--- a/.mise/tasks/test/catalog
+++ b/.mise/tasks/test/catalog
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 #MISE description="Run catalog tests (BATS)"
 set -e
-REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-bats "$REPO_DIR/test/catalog.bats"
+bats "${MISE_CONFIG_ROOT:?MISE_CONFIG_ROOT not set}/test/catalog.bats"

--- a/.mise/tasks/test/dashboard
+++ b/.mise/tasks/test/dashboard
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 #MISE description="Run dashboard tests (BATS)"
 set -e
-REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-bats "$REPO_DIR/test/dashboard.bats"
+bats "${MISE_CONFIG_ROOT:?MISE_CONFIG_ROOT not set}/test/dashboard.bats"


### PR DESCRIPTION
## Summary

- **MISE_CONFIG_ROOT migration** — replace `BASH_SOURCE`/`SCRIPT_DIR`/`REPO_DIR` path resolution with `MISE_CONFIG_ROOT` across all 7 task files (provider, catalog, dashboard, apply, test/*)
- **`--catalog` flag on apply** — variadic flag allowing external catalog directories to be searched alongside the built-in catalog. Enables other tools to ship hook catalog entries:
  ```
  hookers apply agent-stop --catalog $(shiv which escort)/catalog
  ```

## Test plan

- [x] All 24 existing BATS tests pass
- [x] Tested `--catalog` with escort's catalog: `hookers apply agent-stop --catalog ~/agents/x1f9/escort/catalog --dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)