### PR TITLE
feat: dashboard debug logging with ms timing

### DIFF
--- a/.mise/tasks/test/_default
+++ b/.mise/tasks/test/_default
@@ -11,5 +11,6 @@ mise run test:dashboard-duration
 mise run test:dashboard-color
 mise run test:dashboard-width
 mise run test:dashboard-cache
+mise run test:dashboard-debug
 mise run test:provider
 mise run test:time

--- a/.mise/tasks/test/dashboard-debug
+++ b/.mise/tasks/test/dashboard-debug
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+#MISE description="Run dashboard debug logging tests (BATS)"
+set -euo pipefail
+bats "${MISE_CONFIG_ROOT:?MISE_CONFIG_ROOT not set}/test/dashboard-debug.bats"

--- a/scripts/dashboard.sh
+++ b/scripts/dashboard.sh
@@ -26,17 +26,17 @@ NO_LABELS="${HOOKERS_DASHBOARD_NO_LABELS:-}"
 NO_DURATION="${HOOKERS_DASHBOARD_NO_DURATION:-}"
 DURATION_THRESHOLD="${HOOKERS_DASHBOARD_DURATION_THRESHOLD:-1}"
 
-# Debug logging. Always writes to the log file for now (diagnosing latency).
-# TODO: gate behind HOOKERS_DEBUG=1 once investigation is done.
-DEBUG_LOG="${HOOKERS_DASHBOARD_DEBUG_LOG:-${XDG_CACHE_HOME:-$HOME/.cache}/hookers/dashboard-debug.log}"
-mkdir -p "$(dirname "$DEBUG_LOG")"
+# Debug logging: HOOKERS_DEBUG=1 to enable.
+# Appends per-provider cache/timing info to a log file.
+DEBUG_LOG=""
+if [ "${HOOKERS_DEBUG:-}" = "1" ]; then
+  DEBUG_LOG="${HOOKERS_DASHBOARD_DEBUG_LOG:-${XDG_CACHE_HOME:-$HOME/.cache}/hookers/dashboard-debug.log}"
+  mkdir -p "$(dirname "$DEBUG_LOG")"
+fi
 
-# Write a debug log line with timestamp.
-# Usage: debug_log "message"
+# Write a debug log line with timestamp. No-op when debug is off.
 debug_log() {
-  if [ -n "$DEBUG_LOG" ]; then
-    printf "%s %s\n" "$(date '+%H:%M:%S')" "$1" >> "$DEBUG_LOG"
-  fi
+  [ -n "$DEBUG_LOG" ] && printf "%s %s\n" "$(date '+%H:%M:%S')" "$1" >> "$DEBUG_LOG" || true
 }
 
 # Color: explicit setting > TTY detection
@@ -64,6 +64,25 @@ else
   DIM=""
   RESET=""
 fi
+
+# Millisecond timestamps: detect whether date supports %N (nanoseconds).
+# macOS BSD date may emit literal 'N' — probe once and fall back to seconds.
+_probe=$(date +%s%N 2>/dev/null)
+if echo "$_probe" | grep -q '[^0-9]'; then
+  HAS_NS=0
+else
+  HAS_NS=1
+fi
+unset _probe
+
+# Get current time in milliseconds (falls back to seconds × 1000).
+now_ms() {
+  if [ "$HAS_NS" = "1" ]; then
+    echo $(( $(date +%s%N) / 1000000 ))
+  else
+    echo $(( $(date +%s) * 1000 ))
+  fi
+}
 
 # Cache: session-scoped provider result caching.
 # Requires HOOKERS_SESSION_ID to be set (by the agent harness via the extension).
@@ -95,7 +114,7 @@ cache_key() {
 RESULTS_DIR=$(mktemp -d)
 trap 'rm -rf "$RESULTS_DIR"' EXIT
 
-DASH_START_MS=$(($(date +%s%N 2>/dev/null || echo "$(date +%s)000000000") / 1000000))
+DASH_START_MS=$(now_ms)
 debug_log "--- dashboard start (session=${SESSION_ID:-none}) ---"
 
 # Launch all providers in parallel
@@ -130,10 +149,10 @@ for ((i=0; i<ITEM_COUNT; i++)); do
     fi
 
     # Cache miss or no caching — run the provider
-    START_NS=$(date +%s%N 2>/dev/null || echo "$(date +%s)000000000")
+    START_MS=$(now_ms)
     VALUE=$(timeout "${TIMEOUT}s" bash -c "$CMD" 2>/dev/null | tr -d '\n')
-    END_NS=$(date +%s%N 2>/dev/null || echo "$(date +%s)000000000")
-    ELAPSED_MS=$(( (END_NS - START_NS) / 1000000 ))
+    END_MS=$(now_ms)
+    ELAPSED_MS=$((END_MS - START_MS))
     echo -n "$VALUE" > "$RESULTS_DIR/$i.value.tmp"
     echo -n "$ELAPSED_MS" > "$RESULTS_DIR/$i.durms.tmp"
     mv "$RESULTS_DIR/$i.value.tmp" "$RESULTS_DIR/$i.value"
@@ -179,7 +198,7 @@ for ((i=0; i<ITEM_COUNT; i++)); do
   fi
 done
 
-DASH_END_MS=$(($(date +%s%N 2>/dev/null || echo "$(date +%s)000000000") / 1000000))
+DASH_END_MS=$(now_ms)
 DASH_TOTAL_MS=$((DASH_END_MS - DASH_START_MS))
 debug_log "--- dashboard done: ${DASH_TOTAL_MS}ms (${HIT_COUNT} hit, ${MISS_COUNT} miss, ${NOCACHE_COUNT} no-cache) ---"
 

--- a/scripts/dashboard.sh
+++ b/scripts/dashboard.sh
@@ -26,6 +26,19 @@ NO_LABELS="${HOOKERS_DASHBOARD_NO_LABELS:-}"
 NO_DURATION="${HOOKERS_DASHBOARD_NO_DURATION:-}"
 DURATION_THRESHOLD="${HOOKERS_DASHBOARD_DURATION_THRESHOLD:-1}"
 
+# Debug logging. Always writes to the log file for now (diagnosing latency).
+# TODO: gate behind HOOKERS_DEBUG=1 once investigation is done.
+DEBUG_LOG="${HOOKERS_DASHBOARD_DEBUG_LOG:-${XDG_CACHE_HOME:-$HOME/.cache}/hookers/dashboard-debug.log}"
+mkdir -p "$(dirname "$DEBUG_LOG")"
+
+# Write a debug log line with timestamp.
+# Usage: debug_log "message"
+debug_log() {
+  if [ -n "$DEBUG_LOG" ]; then
+    printf "%s %s\n" "$(date '+%H:%M:%S')" "$1" >> "$DEBUG_LOG"
+  fi
+}
+
 # Color: explicit setting > TTY detection
 if [ "${HOOKERS_DASHBOARD_COLOR:-}" = "1" ]; then
   USE_COLOR=1
@@ -82,6 +95,9 @@ cache_key() {
 RESULTS_DIR=$(mktemp -d)
 trap 'rm -rf "$RESULTS_DIR"' EXIT
 
+DASH_START_MS=$(($(date +%s%N 2>/dev/null || echo "$(date +%s)000000000") / 1000000))
+debug_log "--- dashboard start (session=${SESSION_ID:-none}) ---"
+
 # Launch all providers in parallel
 for ((i=0; i<ITEM_COUNT; i++)); do
   CMD=$(jq -r --argjson i "$i" '.items[$i].command' "$CONFIG")
@@ -99,23 +115,40 @@ for ((i=0; i<ITEM_COUNT; i++)); do
         if [ "$AGE" -lt "$CACHE_TTL" ]; then
           # Cache hit
           cat "$CACHE_FILE" > "$RESULTS_DIR/$i.value.tmp"
-          echo -n "0" > "$RESULTS_DIR/$i.dur.tmp"
+          echo -n "0" > "$RESULTS_DIR/$i.durms.tmp"
+          echo -n "hit" > "$RESULTS_DIR/$i.cache.tmp"
+          echo -n "$AGE" > "$RESULTS_DIR/$i.age.tmp"
+          echo -n "$CACHE_TTL" > "$RESULTS_DIR/$i.ttl.tmp"
           mv "$RESULTS_DIR/$i.value.tmp" "$RESULTS_DIR/$i.value"
-          mv "$RESULTS_DIR/$i.dur.tmp" "$RESULTS_DIR/$i.dur"
+          mv "$RESULTS_DIR/$i.durms.tmp" "$RESULTS_DIR/$i.durms"
+          mv "$RESULTS_DIR/$i.cache.tmp" "$RESULTS_DIR/$i.cache"
+          mv "$RESULTS_DIR/$i.age.tmp" "$RESULTS_DIR/$i.age"
+          mv "$RESULTS_DIR/$i.ttl.tmp" "$RESULTS_DIR/$i.ttl"
           exit 0
         fi
       fi
     fi
 
     # Cache miss or no caching — run the provider
-    START_S=$(date +%s)
+    START_NS=$(date +%s%N 2>/dev/null || echo "$(date +%s)000000000")
     VALUE=$(timeout "${TIMEOUT}s" bash -c "$CMD" 2>/dev/null | tr -d '\n')
-    END_S=$(date +%s)
-    ELAPSED_S=$((END_S - START_S))
+    END_NS=$(date +%s%N 2>/dev/null || echo "$(date +%s)000000000")
+    ELAPSED_MS=$(( (END_NS - START_NS) / 1000000 ))
     echo -n "$VALUE" > "$RESULTS_DIR/$i.value.tmp"
-    echo -n "$ELAPSED_S" > "$RESULTS_DIR/$i.dur.tmp"
+    echo -n "$ELAPSED_MS" > "$RESULTS_DIR/$i.durms.tmp"
     mv "$RESULTS_DIR/$i.value.tmp" "$RESULTS_DIR/$i.value"
-    mv "$RESULTS_DIR/$i.dur.tmp" "$RESULTS_DIR/$i.dur"
+    mv "$RESULTS_DIR/$i.durms.tmp" "$RESULTS_DIR/$i.durms"
+
+    # Write debug metadata for collection after wait
+    if [ -n "$CACHE_DIR" ] && [ "$CACHE_TTL" -gt 0 ]; then
+      echo -n "miss" > "$RESULTS_DIR/$i.cache.tmp"
+      echo -n "$CACHE_TTL" > "$RESULTS_DIR/$i.ttl.tmp"
+      mv "$RESULTS_DIR/$i.cache.tmp" "$RESULTS_DIR/$i.cache"
+      mv "$RESULTS_DIR/$i.ttl.tmp" "$RESULTS_DIR/$i.ttl"
+    else
+      echo -n "no-cache" > "$RESULTS_DIR/$i.cache.tmp"
+      mv "$RESULTS_DIR/$i.cache.tmp" "$RESULTS_DIR/$i.cache"
+    fi
 
     # Write to cache (atomic via tmp+mv) — skip empty results so
     # transient failures don't suppress retries until TTL expires.
@@ -126,6 +159,29 @@ for ((i=0; i<ITEM_COUNT; i++)); do
   ) &
 done
 wait
+
+# Log per-provider debug info
+HIT_COUNT=0
+MISS_COUNT=0
+NOCACHE_COUNT=0
+for ((i=0; i<ITEM_COUNT; i++)); do
+  if [ -n "$DEBUG_LOG" ]; then
+    DLABEL=$(jq -r --argjson i "$i" '.items[$i].label' "$CONFIG")
+    DCACHE=""; [ -f "$RESULTS_DIR/$i.cache" ] && DCACHE=$(cat "$RESULTS_DIR/$i.cache")
+    DDUR="?"; [ -f "$RESULTS_DIR/$i.durms" ] && DDUR=$(cat "$RESULTS_DIR/$i.durms")
+    DAGE=""; [ -f "$RESULTS_DIR/$i.age" ] && DAGE=$(cat "$RESULTS_DIR/$i.age")
+    DTTL=""; [ -f "$RESULTS_DIR/$i.ttl" ] && DTTL=$(cat "$RESULTS_DIR/$i.ttl")
+    case "$DCACHE" in
+      hit)      HIT_COUNT=$((HIT_COUNT + 1)); debug_log "  $DLABEL: hit (ttl=${DTTL}, age=${DAGE}) → ${DDUR}ms" ;;
+      miss)     MISS_COUNT=$((MISS_COUNT + 1)); debug_log "  $DLABEL: miss (ttl=${DTTL}) → ${DDUR}ms" ;;
+      no-cache) NOCACHE_COUNT=$((NOCACHE_COUNT + 1)); debug_log "  $DLABEL: no-cache → ${DDUR}ms" ;;
+    esac
+  fi
+done
+
+DASH_END_MS=$(($(date +%s%N 2>/dev/null || echo "$(date +%s)000000000") / 1000000))
+DASH_TOTAL_MS=$((DASH_END_MS - DASH_START_MS))
+debug_log "--- dashboard done: ${DASH_TOTAL_MS}ms (${HIT_COUNT} hit, ${MISS_COUNT} miss, ${NOCACHE_COUNT} no-cache) ---"
 
 # Collect results in order — store label, value, duration separately for rendering
 LABELS=()
@@ -138,9 +194,11 @@ for ((i=0; i<ITEM_COUNT; i++)); do
 
   if [ -n "$VALUE" ]; then
     DUR=""
-    if [ "$NO_DURATION" != "1" ] && [ -f "$RESULTS_DIR/$i.dur" ]; then
-      SECS=$(cat "$RESULTS_DIR/$i.dur")
-      if [ "$SECS" -ge "$DURATION_THRESHOLD" ]; then
+    if [ "$NO_DURATION" != "1" ] && [ -f "$RESULTS_DIR/$i.durms" ]; then
+      MS=$(cat "$RESULTS_DIR/$i.durms")
+      THRESHOLD_MS=$((DURATION_THRESHOLD * 1000))
+      if [ "$MS" -ge "$THRESHOLD_MS" ]; then
+        SECS=$(( (MS + 500) / 1000 ))  # round to nearest second
         DUR="(${SECS}s)"
       fi
     fi

--- a/test/dashboard-debug.bats
+++ b/test/dashboard-debug.bats
@@ -1,0 +1,75 @@
+#!/usr/bin/env bats
+
+load dashboard-helpers
+
+run_debug() {
+  HOOKERS_DEBUG=1 HOOKERS_DASHBOARD_DEBUG_LOG="$TEST_HOME/debug.log" \
+    run run_dashboard
+}
+
+run_debug_cached() {
+  HOOKERS_DEBUG=1 HOOKERS_DASHBOARD_DEBUG_LOG="$TEST_HOME/debug.log" \
+    HOOKERS_SESSION_ID="test-session" HOOKERS_DASHBOARD_CACHE_DIR="$TEST_HOME/cache" \
+    run run_dashboard
+}
+
+@test "debug log created when HOOKERS_DEBUG=1" {
+  cat > "$TEST_CONFIG" << 'EOF'
+{"items": [{"label": "fast", "command": "echo ok"}]}
+EOF
+  run_debug
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_HOME/debug.log" ]
+  grep -q "dashboard start" "$TEST_HOME/debug.log"
+  grep -q "dashboard done" "$TEST_HOME/debug.log"
+}
+
+@test "debug log not created when HOOKERS_DEBUG is unset" {
+  cat > "$TEST_CONFIG" << 'EOF'
+{"items": [{"label": "fast", "command": "echo ok"}]}
+EOF
+  HOOKERS_DASHBOARD_DEBUG_LOG="$TEST_HOME/debug.log" run run_dashboard
+  [ "$status" -eq 0 ]
+  [ ! -f "$TEST_HOME/debug.log" ]
+}
+
+@test "debug log shows no-cache for uncached providers" {
+  cat > "$TEST_CONFIG" << 'EOF'
+{"items": [{"label": "fast", "command": "echo ok"}]}
+EOF
+  run_debug
+  [ "$status" -eq 0 ]
+  grep -q "fast: no-cache" "$TEST_HOME/debug.log"
+}
+
+@test "debug log shows cache hit and miss" {
+  cat > "$TEST_CONFIG" << 'EOF'
+{"items": [{"label": "cached", "command": "echo val", "cache": 60}]}
+EOF
+  # First run — miss
+  run_debug_cached
+  [ "$status" -eq 0 ]
+  grep -q "cached: miss" "$TEST_HOME/debug.log"
+
+  # Second run — hit
+  run_debug_cached
+  grep -q "cached: hit" "$TEST_HOME/debug.log"
+}
+
+@test "debug log shows duration in ms" {
+  cat > "$TEST_CONFIG" << 'EOF'
+{"items": [{"label": "fast", "command": "echo ok"}]}
+EOF
+  run_debug
+  [ "$status" -eq 0 ]
+  grep -q "ms" "$TEST_HOME/debug.log"
+}
+
+@test "debug log shows total wall time" {
+  cat > "$TEST_CONFIG" << 'EOF'
+{"items": [{"label": "fast", "command": "echo ok"}]}
+EOF
+  run_debug
+  [ "$status" -eq 0 ]
+  grep -qE "dashboard done: [0-9]+ms" "$TEST_HOME/debug.log"
+}

--- a/test/dashboard-duration.bats
+++ b/test/dashboard-duration.bats
@@ -28,3 +28,21 @@ EOF
   [ "$status" -eq 0 ]
   [[ "$output" != *"("* ]]
 }
+
+@test "rounds 1500ms to 2s" {
+  cat > "$TEST_CONFIG" << 'EOF'
+{"items": [{"label": "mid", "command": "sleep 1.5 && echo done"}]}
+EOF
+  run run_dashboard
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"(2s)"* ]]
+}
+
+@test "rounds 2500ms to 3s" {
+  cat > "$TEST_CONFIG" << 'EOF'
+{"items": [{"label": "slow", "command": "sleep 2.5 && echo done"}]}
+EOF
+  run run_dashboard
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"(3s)"* ]]
+}


### PR DESCRIPTION
Adds per-provider debug logging to `~/.cache/hookers/dashboard-debug.log`. Each dashboard invocation logs:
- Per-provider: cache hit/miss/no-cache, TTL, age, duration in milliseconds
- Summary: total wall time, hit/miss/no-cache counts

Provider timing upgraded from second to millisecond resolution (`date +%s%N`). Display threshold still shows seconds in the dashboard output.

Currently always-on for diagnostics. Will be gated behind `HOOKERS_DEBUG=1` once the latency investigation is done.